### PR TITLE
Fix connection string helper, docs, and add tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,6 @@ jobs:
       fail-fast: false
       matrix:
         tf-version:
-          - '1.9.*'
-          - '1.10.*'
           - '1.11.*'
     steps:
       - name: Checkout 💻

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - '1.21'
-          - '1.22'
+          - '1.24'
     needs:
       - build
     steps:
@@ -96,7 +95,7 @@ jobs:
       - name: Setup Go environment ⚙️
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Terraform Setup 🏗️
         uses: hashicorp/setup-terraform@v3.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
       matrix:
         tf-version:
           - '1.11.*'
+          - '1.12.*'
     steps:
       - name: Checkout 💻
         uses: actions/checkout@v4.2.2

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,11 +58,11 @@ provider "postgresql" {
 - `host` (String) The hostname of the PostgreSQL server. May be set via the environment variable `POSTGRES_HOST`.
 - `password` (String, Sensitive) The password to use when connecting to the PostgreSQL server. May be set via the environment variable `POSTGRES_PASSWORD`.
 - `port` (Number) The port of the PostgreSQL server. May be set via the environment variable `POSTGRES_PORT`. (default: 5432)
-- `scheme` (String) The schema to use when connecting to the PostgreSQL database. The value must be one of the following:
+- `scheme` (String) The scheme to use when connecting to the PostgreSQL database. The value must be one of the following:
 	* 'postgres' (default)
 	* 'gcppostgres'	
 	* 'awspostgres'
-May be set via the environment variable 'POSTGRES_SCHEMA'. (default: 'postgres')
+May be set via the environment variable 'POSTGRES_SCHEME'. (default: 'postgres')
 - `sslmode` (String) The SSL mode to use when connecting to the PostgreSQL server. The value must be one of the following:
 	* 'disable' (No SSL)
 	* 'require' (*default*. Always SSL, skip verification)

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -71,5 +71,5 @@ resource "postgresql_role" "john_doe" {
 
 ```terraform
 # Postgresql Role can be imported by specifying the id with the format <role_name>
-terraform import postgresql_role.jhon_doe "john_doe"
+terraform import postgresql_role.john_doe "john_doe"
 ```

--- a/docs/resources/user_function.md
+++ b/docs/resources/user_function.md
@@ -27,7 +27,7 @@ resource "postgresql_user_function" "greet_example" {
   EOT
 
   comment = "A simple greeting function"
-  owner   = "jhon_doe"
+  owner   = "john_doe"
 }
 ```
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -97,12 +97,12 @@ func (p *PostgresqlProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 			"scheme": schema.StringAttribute{
 				Optional: true,
 				Description: `
-The schema to use when connecting to the PostgreSQL database. The value must be one of the following:
+The scheme to use when connecting to the PostgreSQL database. The value must be one of the following:
 	* 'postgres' (default)
 	* 'gcppostgres'	
 	* 'awspostgres'
-May be set via the environment variable 'POSTGRES_SCHEMA'. (default: 'postgres')
-				`,
+May be set via the environment variable 'POSTGRES_SCHEME'. (default: 'postgres')
+                                `,
 				Validators: []validator.String{
 					stringvalidator.OneOf("postgres", "gcppostgres", "awspostgres"),
 				},

--- a/internal/test/testcontainer.go
+++ b/internal/test/testcontainer.go
@@ -87,5 +87,7 @@ func GetPostgresConnectionString(t *testing.T, container *postgres.PostgresConta
 		queryParams.Set("sslmode", "disable")
 	}
 
-	return connString + queryParams.Encode()
+	u.RawQuery = queryParams.Encode()
+
+	return u.String()
 }

--- a/internal/test/testcontainer_test.go
+++ b/internal/test/testcontainer_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+func TestGetPostgresConnectionString(t *testing.T) {
+	pgContainer := LoadPostgresTestContainer(t, PostgresContainerRunOptions{}, false)
+	t.Cleanup(func() {
+		assert.NoError(t, pgContainer.Terminate(context.Background()))
+	})
+
+	connString := GetPostgresConnectionString(t, pgContainer)
+
+	u, err := url.Parse(connString)
+	assert.NoError(t, err)
+	assert.Equal(t, "disable", u.Query().Get("sslmode"))
+}


### PR DESCRIPTION
## Summary
- fix example typos in role and user_function docs
- clarify provider `scheme` description and environment variable
- correct DSN assembly in GetPostgresConnectionString
- add unit test for the helper

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68499e96927c8330818b15e1fd687a7d